### PR TITLE
ChatFull has a recursive nesting

### DIFF
--- a/src/OpenTl.Schema/_generated/Messages/ChatFull/IChatFull.cs
+++ b/src/OpenTl.Schema/_generated/Messages/ChatFull/IChatFull.cs
@@ -9,7 +9,7 @@ namespace OpenTl.Schema.Messages
 
     public interface IChatFull : IObject
     {
-       IChatFull FullChat {get; set;}
+       Schema.IChatFull FullChat {get; set;}
 
        TVector<IChat> Chats {get; set;}
 

--- a/src/OpenTl.Schema/_generated/Messages/ChatFull/TChatFull.cs
+++ b/src/OpenTl.Schema/_generated/Messages/ChatFull/TChatFull.cs
@@ -13,7 +13,7 @@ namespace OpenTl.Schema.Messages
 	public class TChatFull : IChatFull
 	{
        [SerializationOrder(0)]
-       public IChatFull FullChat {get; set;}
+       public Schema.IChatFull FullChat {get; set;}
 
        [SerializationOrder(1)]
        public TVector<IChat> Chats {get; set;}


### PR DESCRIPTION
There are errors during deserialization because of the recursive nesting of the ChatFull.